### PR TITLE
Add Redis logging provider implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Microsoft.Extensions.Logging.Redis
-A Redis ILogger, based off serilog-sinks-redis
+A Redis `ILogger` provider that writes log events to a Redis list using [StackExchange.Redis](https://stackexchange.github.io/StackExchange.Redis/).
+
+## Usage
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+var builder = Host.CreateDefaultBuilder(args)
+    .ConfigureLogging(logging =>
+    {
+        logging.ClearProviders();
+        logging.AddRedis("localhost:6379", "logs");
+    });
+```

--- a/src/Microsoft.Extensions.Logging.Redis/Microsoft.Extensions.Logging.Redis.csproj
+++ b/src/Microsoft.Extensions.Logging.Redis/Microsoft.Extensions.Logging.Redis.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    <PackageReference Include="StackExchange.Redis" Version="2.9.25" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Extensions.Logging.Redis/RedisLogEntry.cs
+++ b/src/Microsoft.Extensions.Logging.Redis/RedisLogEntry.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Extensions.Logging.Redis;
+
+internal sealed record RedisLogEntry(
+    [property: JsonPropertyName("timestamp")] DateTimeOffset Timestamp,
+    [property: JsonPropertyName("level")] string Level,
+    [property: JsonPropertyName("category")] string Category,
+    [property: JsonPropertyName("eventId")] int? EventId,
+    [property: JsonPropertyName("eventName")] string? EventName,
+    [property: JsonPropertyName("message")] string? Message,
+    [property: JsonPropertyName("exception")] string? Exception,
+    [property: JsonPropertyName("state")] object? State);

--- a/src/Microsoft.Extensions.Logging.Redis/RedisLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Redis/RedisLogger.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging.Redis;
+
+internal sealed class RedisLogger : ILogger
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static readonly IDisposable NoOpScope = new NoOpDisposable();
+
+    private readonly RedisLoggerProvider _provider;
+    private readonly string _categoryName;
+
+    public RedisLogger(RedisLoggerProvider provider, string categoryName)
+    {
+        _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        _categoryName = categoryName ?? throw new ArgumentNullException(nameof(categoryName));
+    }
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NoOpScope;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        if (formatter is null)
+        {
+            throw new ArgumentNullException(nameof(formatter));
+        }
+
+        var message = formatter(state, exception);
+
+        if (string.IsNullOrEmpty(message) && exception is null)
+        {
+            return;
+        }
+
+        var entry = new RedisLogEntry(
+            DateTimeOffset.UtcNow,
+            logLevel.ToString(),
+            _categoryName,
+            eventId.Id != 0 ? eventId.Id : null,
+            eventId.Name,
+            message,
+            exception?.ToString(),
+            CaptureState(state));
+
+        var payload = JsonSerializer.Serialize(entry, SerializerOptions);
+        try
+        {
+            _provider.Write(payload);
+        }
+        catch
+        {
+            // Swallow exceptions from Redis writes to avoid crashing the application logging pipeline.
+        }
+    }
+
+    private sealed class NoOpDisposable : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+
+    private static object? CaptureState<TState>(TState state)
+    {
+        if (state is null)
+        {
+            return null;
+        }
+
+        if (state is IReadOnlyList<KeyValuePair<string, object?>> kvps)
+        {
+            return kvps
+                .Where(kvp => !string.Equals(kvp.Key, "{OriginalFormat}", StringComparison.Ordinal))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal);
+        }
+
+        if (state is IEnumerable<KeyValuePair<string, object?>> enumerable)
+        {
+            return enumerable
+                .Where(kvp => !string.Equals(kvp.Key, "{OriginalFormat}", StringComparison.Ordinal))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal);
+        }
+
+        return state.ToString();
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Redis/RedisLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Redis/RedisLoggerProvider.cs
@@ -1,0 +1,61 @@
+using System;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace Microsoft.Extensions.Logging.Redis;
+
+internal sealed class RedisLoggerProvider : ILoggerProvider
+{
+    private readonly string _listKey;
+    private readonly ConnectionMultiplexer _connection;
+    private readonly IDatabase _database;
+    private bool _disposed;
+
+    public RedisLoggerProvider(string connectionString, string listKey)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new ArgumentException("The connection string must be provided.", nameof(connectionString));
+        }
+
+        if (string.IsNullOrWhiteSpace(listKey))
+        {
+            throw new ArgumentException("The list key must be provided.", nameof(listKey));
+        }
+
+        _listKey = listKey;
+        _connection = ConnectionMultiplexer.Connect(connectionString);
+        _database = _connection.GetDatabase();
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(RedisLoggerProvider));
+        }
+
+        return new RedisLogger(this, categoryName);
+    }
+
+    internal void Write(RedisValue value)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _database.ListRightPush(_listKey, value);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _connection.Dispose();
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Redis/RedisLoggingBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Redis/RedisLoggingBuilderExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging.Redis;
+
+public static class RedisLoggingBuilderExtensions
+{
+    public static ILoggingBuilder AddRedis(this ILoggingBuilder builder, string connectionString, string listKey)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new ArgumentException("The connection string must be provided.", nameof(connectionString));
+        }
+
+        if (string.IsNullOrWhiteSpace(listKey))
+        {
+            throw new ArgumentException("The list key must be provided.", nameof(listKey));
+        }
+
+        builder.Services.AddSingleton<ILoggerProvider>(_ => new RedisLoggerProvider(connectionString, listKey));
+        return builder;
+    }
+}


### PR DESCRIPTION
## Summary
- implement a Redis-backed ILogger provider that pushes log entries into a Redis list
- add an ILoggingBuilder extension for wiring the provider into Host logging configuration
- document basic usage in the README

## Testing
- dotnet build src/Microsoft.Extensions.Logging.Redis/Microsoft.Extensions.Logging.Redis.csproj

## Prompt:
```
Using https://github.com/dburriss/serilog-sinks-redis for guidance, implement an 
ILogger that will write a Redis list. When creating the logger, it should take a connection 
string and list key. There should be an extension method that wires up the logger, e.g.:

var builder = Host.CreateDefaultBuilder(args)
    .ConfigureLogging(logging =>
    {
        logging.ClearProviders();
        logging.AddRedis(connectionString, key);
    });
```

------
https://chatgpt.com/codex/tasks/task_e_68e127cf4cb0832fab0cefc68ed6e53a