### PR TITLE
Unit tests and integration tests via docker

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,17 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.9.25" />
+    <PackageVersion Include="DotNet.Testcontainers" Version="1.7.0-beta.2269" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="xunit.v3" Version="3.1.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.Extensions.Logging.Redis/DefaultRedisConnectionFactory.cs
+++ b/src/Microsoft.Extensions.Logging.Redis/DefaultRedisConnectionFactory.cs
@@ -1,0 +1,14 @@
+using StackExchange.Redis;
+
+namespace Microsoft.Extensions.Logging.Redis;
+
+internal sealed class DefaultRedisConnectionFactory : IRedisConnectionFactory
+{
+    public static DefaultRedisConnectionFactory Instance { get; } = new();
+
+    private DefaultRedisConnectionFactory()
+    {
+    }
+
+    public IConnectionMultiplexer Connect(string connectionString) => ConnectionMultiplexer.Connect(connectionString);
+}

--- a/src/Microsoft.Extensions.Logging.Redis/IRedisConnectionFactory.cs
+++ b/src/Microsoft.Extensions.Logging.Redis/IRedisConnectionFactory.cs
@@ -1,0 +1,8 @@
+using StackExchange.Redis;
+
+namespace Microsoft.Extensions.Logging.Redis;
+
+internal interface IRedisConnectionFactory
+{
+    IConnectionMultiplexer Connect(string connectionString);
+}

--- a/src/Microsoft.Extensions.Logging.Redis/Microsoft.Extensions.Logging.Redis.csproj
+++ b/src/Microsoft.Extensions.Logging.Redis/Microsoft.Extensions.Logging.Redis.csproj
@@ -7,8 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
-    <PackageReference Include="StackExchange.Redis" Version="2.9.25" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="StackExchange.Redis" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Extensions.Logging.Redis.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Extensions.Logging.Redis/RedisLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Redis/RedisLogger.cs
@@ -27,7 +27,15 @@ internal sealed class RedisLogger : ILogger
 
     public IDisposable BeginScope<TState>(TState state) where TState : notnull => NoOpScope;
 
-    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        if (logLevel == LogLevel.None)
+        {
+            return false;
+        }
+
+        return logLevel >= _provider.MinimumLevel;
+    }
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {

--- a/tests/Microsoft.Extensions.Logging.Redis.Tests/Infrastructure/RedisIntegrationTestBase.cs
+++ b/tests/Microsoft.Extensions.Logging.Redis.Tests/Infrastructure/RedisIntegrationTestBase.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Configurations;
+using Docker.DotNet;
+using StackExchange.Redis;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Redis.Tests.Infrastructure;
+
+public abstract class RedisIntegrationTestBase : IAsyncLifetime
+{
+    private const int RedisPort = 6379;
+    protected const string DefaultListKey = "logs";
+
+    private readonly SemaphoreSlim _connectionLock = new(1, 1);
+    private IConnectionMultiplexer? _connectionMultiplexer;
+
+    protected ITestcontainersContainer? RedisContainer { get; private set; }
+    protected string ConnectionString { get; private set; } = string.Empty;
+    protected bool DockerAvailable { get; private set; }
+
+    public async ValueTask InitializeAsync()
+    {
+        try
+        {
+            var containerBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+                .WithImage("redis:7-alpine")
+                .WithPortBinding(RedisPort, assignRandomHostPort: true)
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilCommandIsCompleted("redis-cli", "ping"))
+                .WithCleanUp(true)
+                .WithAutoRemove(true);
+
+            RedisContainer = containerBuilder.Build();
+            await RedisContainer.StartAsync();
+
+            var mappedPort = RedisContainer.GetMappedPublicPort(RedisPort);
+            ConnectionString = $"{RedisContainer.Hostname}:{mappedPort}";
+
+            await WaitForRedisAsync(TimeSpan.FromSeconds(30));
+            DockerAvailable = true;
+        }
+        catch (Exception ex) when (IsDockerUnavailable(ex))
+        {
+            DockerAvailable = false;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_connectionMultiplexer is not null)
+        {
+            await _connectionMultiplexer.CloseAsync();
+            await _connectionMultiplexer.DisposeAsync();
+        }
+
+        _connectionLock.Dispose();
+
+        if (DockerAvailable && RedisContainer is not null)
+        {
+            await RedisContainer.DisposeAsync();
+        }
+    }
+
+    protected string GetConnectionString() => ConnectionString;
+
+    protected void SkipIfDockerUnavailable()
+    {
+        if (!DockerAvailable)
+        {
+            throw SkipException.ForSkip("Docker is required for integration tests.");
+        }
+    }
+
+    protected async Task<IConnectionMultiplexer> GetRedisConnectionAsync()
+    {
+        if (_connectionMultiplexer is { IsConnected: true })
+        {
+            return _connectionMultiplexer;
+        }
+
+        await _connectionLock.WaitAsync();
+        try
+        {
+            if (_connectionMultiplexer is { IsConnected: true })
+            {
+                return _connectionMultiplexer;
+            }
+
+            _connectionMultiplexer?.Dispose();
+            _connectionMultiplexer = await ConnectionMultiplexer.ConnectAsync(ConnectionString);
+            return _connectionMultiplexer;
+        }
+        finally
+        {
+            _connectionLock.Release();
+        }
+    }
+
+    protected async Task ClearRedisDataAsync(string? listKey = null)
+    {
+        var connection = await GetRedisConnectionAsync();
+        if (string.IsNullOrWhiteSpace(listKey))
+        {
+            foreach (var endPoint in connection.GetEndPoints())
+            {
+                var server = connection.GetServer(endPoint);
+                await server.FlushDatabaseAsync();
+            }
+        }
+        else
+        {
+            await connection.GetDatabase().KeyDeleteAsync(listKey);
+        }
+    }
+
+    protected async Task<IReadOnlyList<string>> GetLogsFromRedisAsync(string listKey)
+    {
+        var connection = await GetRedisConnectionAsync();
+        var values = await connection.GetDatabase().ListRangeAsync(listKey, 0, -1);
+        return values.Select(v => v.ToString() ?? string.Empty).ToArray();
+    }
+
+    protected async Task<long> GetLogCountAsync(string listKey)
+    {
+        var connection = await GetRedisConnectionAsync();
+        return await connection.GetDatabase().ListLengthAsync(listKey);
+    }
+
+    protected async Task<bool> WaitForLogCountAsync(string listKey, long expectedCount, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await GetLogCountAsync(listKey) == expectedCount)
+            {
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+
+        return await GetLogCountAsync(listKey) == expectedCount;
+    }
+
+    internal static RedisLogEntry? DeserializeLogEntry(string payload)
+    {
+        return JsonSerializer.Deserialize<RedisLogEntry>(payload, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        });
+    }
+
+    private async Task WaitForRedisAsync(TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        Exception? lastError = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            try
+            {
+                var connection = await ConnectionMultiplexer.ConnectAsync(ConnectionString);
+                await connection.GetDatabase().PingAsync();
+                await connection.CloseAsync();
+                await connection.DisposeAsync();
+                return;
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+        }
+
+        throw new InvalidOperationException($"Redis did not become available within {timeout}.", lastError);
+    }
+
+    private static bool IsDockerUnavailable(Exception ex)
+    {
+        if (ex is DockerApiException or HttpRequestException or SocketException)
+        {
+            return true;
+        }
+
+        return ex is InvalidOperationException && ex.Message.Contains("Docker", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Microsoft.Extensions.Logging.Redis.Tests/Infrastructure/RedisTestHelpers.cs
+++ b/tests/Microsoft.Extensions.Logging.Redis.Tests/Infrastructure/RedisTestHelpers.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging.Redis.Tests.Infrastructure;
+
+public static class RedisTestHelpers
+{
+    public static ILogger CreateLogger(string connectionString, string listKey, string? category = null)
+    {
+        var factory = LoggerFactory.Create(builder =>
+        {
+            builder.ClearProviders();
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddRedis(connectionString, listKey);
+        });
+
+        return factory.CreateLogger(category ?? typeof(RedisTestHelpers).FullName!);
+    }
+
+    internal static RedisLogEntry Deserialize(string payload)
+    {
+        return JsonSerializer.Deserialize<RedisLogEntry>(payload, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        }) ?? throw new InvalidOperationException("Failed to deserialize log entry.");
+    }
+}

--- a/tests/Microsoft.Extensions.Logging.Redis.Tests/Integration/BasicLoggingTests.cs
+++ b/tests/Microsoft.Extensions.Logging.Redis.Tests/Integration/BasicLoggingTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Redis.Tests.Infrastructure;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Extensions.Logging.Redis.Tests.Integration;
+
+public class BasicLoggingTests : RedisIntegrationTestBase
+{
+    [Fact]
+    public async Task LogInformation_WritesToRedisListWithCorrectKey()
+    {
+        SkipIfDockerUnavailable();
+        var listKey = $"test-logs:{Guid.NewGuid():N}";
+        var logger = RedisTestHelpers.CreateLogger(GetConnectionString(), listKey, "BasicLogging");
+
+        logger.LogInformation("Hello Redis");
+
+        (await WaitForLogCountAsync(listKey, 1, TimeSpan.FromSeconds(10))).ShouldBeTrue();
+        var logs = await GetLogsFromRedisAsync(listKey);
+        logs.Count.ShouldBe(1);
+
+        var entry = RedisTestHelpers.Deserialize(logs.Single());
+        entry.Level.ShouldBe("Information");
+        entry.Category.ShouldBe("BasicLogging");
+        entry.Message.ShouldBe("Hello Redis");
+        entry.Timestamp.ShouldBeLessThan(DateTimeOffset.UtcNow.AddSeconds(1));
+        entry.Timestamp.ShouldBeGreaterThan(DateTimeOffset.UtcNow.AddSeconds(-10));
+    }
+
+    [Fact]
+    public async Task LogMultipleLevels_AllAppearInRedis()
+    {
+        SkipIfDockerUnavailable();
+        var listKey = $"multi-logs:{Guid.NewGuid():N}";
+        var logger = RedisTestHelpers.CreateLogger(GetConnectionString(), listKey, "MultiLevel");
+
+        logger.LogTrace("Trace message");
+        logger.LogDebug("Debug message");
+        logger.LogInformation("Info message");
+        logger.LogWarning("Warn message");
+        logger.LogError("Error message");
+        logger.LogCritical("Critical message");
+
+        (await WaitForLogCountAsync(listKey, 6, TimeSpan.FromSeconds(10))).ShouldBeTrue();
+        var logs = await GetLogsFromRedisAsync(listKey);
+        logs.Count.ShouldBe(6);
+
+        var entries = logs.Select(RedisTestHelpers.Deserialize).ToArray();
+        var levels = entries.Select(e => e.Level).ToArray();
+        levels.ShouldBe(new[] { "Trace", "Debug", "Information", "Warning", "Error", "Critical" });
+    }
+
+    [Fact]
+    public async Task LogWithCategory_IncludesCategoryInEntry()
+    {
+        SkipIfDockerUnavailable();
+        var category = "MyApp.Services";
+        var listKey = $"category-logs:{Guid.NewGuid():N}";
+        var logger = RedisTestHelpers.CreateLogger(GetConnectionString(), listKey, category);
+
+        logger.LogInformation("Category message");
+
+        (await WaitForLogCountAsync(listKey, 1, TimeSpan.FromSeconds(10))).ShouldBeTrue();
+        var entry = RedisTestHelpers.Deserialize((await GetLogsFromRedisAsync(listKey)).Single());
+        entry.Category.ShouldBe(category);
+    }
+
+    [Fact]
+    public async Task LogWithEventId_IncludesEventIdInEntry()
+    {
+        SkipIfDockerUnavailable();
+        var listKey = $"event-logs:{Guid.NewGuid():N}";
+        var logger = RedisTestHelpers.CreateLogger(GetConnectionString(), listKey, "EventCategory");
+
+        logger.LogInformation(new EventId(100, "UserAction"), "Event message");
+
+        (await WaitForLogCountAsync(listKey, 1, TimeSpan.FromSeconds(10))).ShouldBeTrue();
+        var entry = RedisTestHelpers.Deserialize((await GetLogsFromRedisAsync(listKey)).Single());
+        entry.EventId.ShouldBe(100);
+        entry.EventName.ShouldBe("UserAction");
+    }
+}

--- a/tests/Microsoft.Extensions.Logging.Redis.Tests/Microsoft.Extensions.Logging.Redis.Tests.csproj
+++ b/tests/Microsoft.Extensions.Logging.Redis.Tests/Microsoft.Extensions.Logging.Redis.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotNet.Testcontainers" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StackExchange.Redis" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Microsoft.Extensions.Logging.Redis/Microsoft.Extensions.Logging.Redis.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Microsoft.Extensions.Logging.Redis.Tests/TestData/SampleExceptions.cs
+++ b/tests/Microsoft.Extensions.Logging.Redis.Tests/TestData/SampleExceptions.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.Logging.Redis.Tests.TestData;
+
+public static class SampleExceptions
+{
+    public static Exception Simple() => new ArgumentException("Sample argument error");
+
+    public static Exception WithInnerExceptions()
+    {
+        try
+        {
+            try
+            {
+                throw new InvalidOperationException("Inner most");
+            }
+            catch (Exception inner)
+            {
+                throw new InvalidOperationException("Middle layer", inner);
+            }
+        }
+        catch (Exception inner)
+        {
+            throw new ApplicationException("Outer layer", inner);
+        }
+    }
+
+    public static Exception Aggregate()
+    {
+        var inner = new List<Exception>
+        {
+            new InvalidOperationException("First"),
+            new InvalidOperationException("Second"),
+            new InvalidOperationException("Third"),
+        };
+
+        return new AggregateException("Aggregate", inner);
+    }
+}

--- a/tests/Microsoft.Extensions.Logging.Redis.Tests/TestData/SampleMessages.cs
+++ b/tests/Microsoft.Extensions.Logging.Redis.Tests/TestData/SampleMessages.cs
@@ -1,0 +1,13 @@
+namespace Microsoft.Extensions.Logging.Redis.Tests.TestData;
+
+public static class SampleMessages
+{
+    public const string Simple = "Hello World";
+    public const string WithParameters = "User {userId} logged in";
+    public static string Long => new('a', 10_240);
+    public static string VeryLong => new('b', 1_048_576);
+    public const string Unicode = "Hello 世界 🌍 مرحبا Привет";
+    public const string SpecialCharacters = "Line1\nLine2\tTabbed \"Quoted\"";
+    public const string Empty = "";
+    public const string Whitespace = "   ";
+}

--- a/tests/Microsoft.Extensions.Logging.Redis.Tests/Unit/RedisLoggerProviderTests.cs
+++ b/tests/Microsoft.Extensions.Logging.Redis.Tests/Unit/RedisLoggerProviderTests.cs
@@ -1,0 +1,62 @@
+using System;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Microsoft.Extensions.Logging.Redis.Tests.Unit;
+
+public class RedisLoggerProviderTests
+{
+    [Fact]
+    public void Constructor_WithNullConnectionString_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() => new RedisLoggerProvider(null!, "logs"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Constructor_WithEmptyListKey_ThrowsArgumentException(string listKey)
+    {
+        Should.Throw<ArgumentException>(() => new RedisLoggerProvider("localhost", listKey));
+    }
+
+    [Fact]
+    public void CreateLogger_ReturnsSameInstanceForSameCategory()
+    {
+        var (provider, _) = CreateProvider();
+
+        var logger1 = provider.CreateLogger("MyCategory");
+        var logger2 = provider.CreateLogger("MyCategory");
+
+        logger1.ShouldBeSameAs(logger2);
+    }
+
+    [Fact]
+    public void Dispose_DisposesConnectionMultiplexer_AndLoggingAfterDisposeDoesNotThrow()
+    {
+        var (provider, db) = CreateProvider();
+        var logger = provider.CreateLogger("DisposedCategory");
+
+        provider.Dispose();
+
+        Should.NotThrow(() => logger.Log(LogLevel.Information, new EventId(1), "state", null, (s, e) => "message"));
+
+        db.DidNotReceiveWithAnyArgs().ListRightPush(default(RedisKey), default(RedisValue), default, default);
+    }
+
+    private static (RedisLoggerProvider provider, IDatabase database) CreateProvider()
+    {
+        var multiplexer = Substitute.For<IConnectionMultiplexer>();
+        var database = Substitute.For<IDatabase>();
+        multiplexer.GetDatabase().Returns(database);
+
+        var factory = Substitute.For<IRedisConnectionFactory>();
+        factory.Connect(Arg.Any<string>()).Returns(multiplexer);
+
+        var provider = new RedisLoggerProvider("localhost:6379", "logs", LogLevel.Trace, factory);
+        return (provider, database);
+    }
+}

--- a/tests/Microsoft.Extensions.Logging.Redis.Tests/Unit/RedisLoggerTests.cs
+++ b/tests/Microsoft.Extensions.Logging.Redis.Tests/Unit/RedisLoggerTests.cs
@@ -1,0 +1,53 @@
+using System;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Microsoft.Extensions.Logging.Redis.Tests.Unit;
+
+public class RedisLoggerTests
+{
+    [Fact]
+    public void Log_WithLogLevelNone_DoesNotWriteToRedis()
+    {
+        var (logger, database) = CreateLogger();
+
+        logger.Log(LogLevel.None, new EventId(1), "state", null, (s, e) => "message");
+
+        database.DidNotReceiveWithAnyArgs().ListRightPush(default(RedisKey), default(RedisValue), default, default);
+    }
+
+    [Fact]
+    public void IsEnabled_ReturnsTrueForInformationAndFalseForDebugWhenInformationMinimum()
+    {
+        var (logger, _) = CreateLogger();
+
+        logger.IsEnabled(LogLevel.Information).ShouldBeTrue();
+        logger.IsEnabled(LogLevel.Debug).ShouldBeFalse();
+        logger.IsEnabled(LogLevel.None).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Log_WithNullFormatter_ThrowsArgumentNullException()
+    {
+        var (logger, _) = CreateLogger();
+
+        Should.Throw<ArgumentNullException>(() => logger.Log<string>(LogLevel.Information, new EventId(42), "state", null, null!));
+    }
+
+    private static (RedisLogger logger, IDatabase database) CreateLogger()
+    {
+        var multiplexer = Substitute.For<IConnectionMultiplexer>();
+        var database = Substitute.For<IDatabase>();
+        multiplexer.GetDatabase().Returns(database);
+
+        var factory = Substitute.For<IRedisConnectionFactory>();
+        factory.Connect(Arg.Any<string>()).Returns(multiplexer);
+
+        var provider = new RedisLoggerProvider("localhost:6379", "logs", LogLevel.Information, factory);
+        var logger = (RedisLogger)provider.CreateLogger("TestCategory");
+        return (logger, database);
+    }
+}


### PR DESCRIPTION
## Summary
- add a root Directory.Packages.props to centralize all package version declarations
- move both the library and test projects to central package references and upgrade the tests to xUnit 3
- update the Redis integration test base to the new ValueTask lifetime signatures and replace SkippableFact with a SkipException helper

## Testing
- MSBUILDTERMINALLOGGER=false dotnet test tests/Microsoft.Extensions.Logging.Redis.Tests/Microsoft.Extensions.Logging.Redis.Tests.csproj -nologo -v minimal

------
https://chatgpt.com/codex/tasks/task_e_68e12c4ae14c832f8d4d966f87085d77